### PR TITLE
Provide alternative to `crypto.randomUUID` via `uuid` package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-web-pouch-edv ChangeLog
 
+## 2.0.1 - TBD
+
+### Fixed
+- Provide alternative to `crypto.randomUUID` via `uuid` package.
+
 ## 2.0.0 - 2022-02-23
 
 ### Changed

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,6 +3,7 @@
  */
 import * as base58 from 'base58-universal';
 import {assert} from './assert.js';
+import {v4 as uuidv4} from 'uuid';
 
 let _getRandomBytes;
 
@@ -95,7 +96,10 @@ export function multihashEncode({codec = 0x00, data, multibase = 'z'} = {}) {
 }
 
 export function uuid() {
-  return crypto.randomUUID();
+  if(crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return uuidv4();
 }
 
 function _createGetRandomBytes() {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@digitalbazaar/edv-client": "^12.0.0",
     "base58-universal": "^1.0.0",
     "pouchdb": "^7.2.2",
-    "pouchdb-find": "^7.2.2"
+    "pouchdb-find": "^7.2.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "eslint": "^7.3.1",


### PR DESCRIPTION
Fixes #4.