### PR TITLE
Add configurable PouchDB adapter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # bedrock-web-pouch-edv ChangeLog
 
+## 8.3.0 - 2026-07-dd
+
+### Added
+- Add `setAdapter()` and `getAdapter()` to configure the PouchDB adapter used
+  by databases created without an explicit `adapter` option. This allows hosts
+  with no IndexedDB implementation (e.g. React Native, using
+  `pouchdb-adapter-react-native-sqlite`) to reuse this library. Encryption
+  occurs above this layer, so the adapter only ever sees ciphertext and the
+  security model is unaffected by the choice of adapter.
+
+### Changed
+- `purge()` now falls back to PouchDB's `compact()` when a non-`indexeddb`
+  adapter is configured, since the existing implementation reaches past PouchDB
+  into IndexedDB directly. The `indexeddb` code path is unchanged. The fallback
+  reports `{deleted: 0}` because `compact()` does not return a count.
+
+### Notes
+- Default behavior is unchanged: the adapter still defaults to `indexeddb`, so
+  existing browser consumers are unaffected.
+
 ## 8.2.1 - 2026-07-27
 
 ### Fixed

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2026 Digital Bazaar, Inc. All rights reserved.
  */
 import * as chunks from './chunks.js';
 import * as docs from './docs.js';
@@ -9,4 +9,5 @@ import * as secrets from './secrets.js';
 export {chunks, docs, edvs, secrets};
 export {initialize} from './initialize.js';
 export {generateLocalId} from './helpers.js';
+export {getAdapter, setAdapter} from './pouchdb.js';
 export {PouchEdvClient} from './PouchEdvClient.js';

--- a/lib/pouchdb.js
+++ b/lib/pouchdb.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2021-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2021-2026 Digital Bazaar, Inc. All rights reserved.
  */
 import {assert} from './assert.js';
 import PouchDB from 'pouchdb';
@@ -9,6 +9,13 @@ import pouchIndexedDB from 'pouchdb-adapter-indexeddb';
 export {PouchDB};
 
 const PREFIX = 'br_edv_';
+
+const DEFAULT_ADAPTER = 'indexeddb';
+
+/* The adapter used when `createDatabase` is called without an explicit
+`adapter`. Defaults to `indexeddb` so browser behavior is unchanged; hosts
+without IndexedDB (e.g. React Native) call `setAdapter()` at startup. */
+let _defaultAdapter = DEFAULT_ADAPTER;
 
 // support queries and indexing
 PouchDB.plugin(pouchFind);
@@ -27,9 +34,53 @@ PouchDB.plugin({insertOne, updateOne});
 // debugPouch(PouchDB);
 // PouchDB.debug.enable('pouchdb:find');
 
+/**
+ * Sets the PouchDB adapter used by databases created without an explicit
+ * `adapter` option, optionally registering the adapter's plugin.
+ *
+ * This enables hosts that have no IndexedDB implementation (e.g. React Native,
+ * where `pouchdb-adapter-react-native-sqlite` is used instead) to reuse this
+ * library. Encryption happens above this layer, so the adapter only ever sees
+ * ciphertext and the security model is unaffected by the choice of adapter.
+ *
+ * Must be called before any database is opened; databases already created
+ * keep the adapter they were opened with.
+ *
+ * @param {object} options - The options to use.
+ * @param {string} options.adapter - The name of a registered PouchDB adapter.
+ * @param {object|Function} [options.plugin] - The adapter's PouchDB plugin, to
+ *   be registered before the adapter name is used.
+ */
+export function setAdapter({adapter, plugin} = {}) {
+  assert.string(adapter, 'adapter');
+  if(plugin !== undefined) {
+    /* Note: `PouchDB.plugin()` accepts either an object of methods to mix in
+    or a function that receives `PouchDB`. Adapter packages such as
+    `pouchdb-adapter-indexeddb` and `pouchdb-adapter-react-native-sqlite`
+    export functions, whereas e.g. `pouchdb-find` exports an object, so both
+    shapes must be permitted here. */
+    if(!(plugin && (typeof plugin === 'object' ||
+      typeof plugin === 'function'))) {
+      throw new TypeError('"plugin" must be an object or a function.');
+    }
+    PouchDB.plugin(plugin);
+  }
+  _defaultAdapter = adapter;
+}
+
+/**
+ * Gets the name of the adapter used for databases created without an explicit
+ * `adapter` option.
+ *
+ * @returns {string} The current default adapter name.
+ */
+export function getAdapter() {
+  return _defaultAdapter;
+}
+
 // create a pouch DB database w/auto-upgrade flag
 export async function createDatabase({
-  name, auto_compaction = true, adapter = 'indexeddb'
+  name, auto_compaction = true, adapter = _defaultAdapter
 } = {}) {
   const client = new PouchDB(PREFIX + name, {
     auto_compaction,
@@ -42,6 +93,22 @@ export async function createDatabase({
 
 // purge all deleted documents in a pouch DB database
 export async function purge({name} = {}) {
+  /* The implementation below reaches past PouchDB into IndexedDB directly, so
+  it only works for the `indexeddb` adapter. For any other adapter, fall back
+  to PouchDB's own `compact()`, which is the portable way to reclaim space
+  taken by deleted documents. `compact()` does not report how many records it
+  removed, so `deleted` is reported as 0; callers treat purging as best-effort
+  storage reclamation rather than relying on the count. */
+  if(_defaultAdapter !== DEFAULT_ADAPTER) {
+    const db = await createDatabase({name});
+    try {
+      await db.compact();
+    } finally {
+      await db.close();
+    }
+    return {deleted: 0};
+  }
+
   // purge any deleted records to recover storage space
   let db;
   let deleted = 0;


### PR DESCRIPTION
**Draft** — opened for design feedback on the seam before it is polished. See the open questions at the end.

## Problem

`lib/pouchdb.js` binds local storage to IndexedDB in three separate ways, all of which have to change for a non-browser host (React Native, in this case) to reuse this package:

1. **The adapter plugin is imported unconditionally**, so the import alone pulls IndexedDB code into any bundle:
   ```js
   import pouchIndexedDB from 'pouchdb-adapter-indexeddb';
   PouchDB.plugin(pouchIndexedDB);
   ```
2. **`adapter` defaults to `'indexeddb'` and no caller ever passes it.** `createDatabase` does accept the option, but all internal call sites (`lib/docs.js`, `lib/chunks.js`, `lib/ConfigStorage.js`) omit it, so the default always wins. The existing parameter is therefore not a usable extension point today — threading it through would touch every caller and every caller's caller.
3. **`purge()` bypasses PouchDB entirely** and calls `indexedDB.open(name)` directly, which is adapter-specific by construction.

## Change

Adds `setAdapter()` and `getAdapter()`, plus a module-level default that `createDatabase` reads. This is a smaller diff than threading `adapter` through every call site, and keeps existing behavior byte-identical.

`purge()` falls back to PouchDB's `compact()` when a non-`indexeddb` adapter is configured; the IndexedDB path is untouched. The fallback reports `{deleted: 0}` because `compact()` returns no count.

**The default remains `indexeddb`, so existing browser consumers are unaffected.**

## Why this does not affect the security model

Encryption happens above this layer, in `minimal-cipher`. The adapter only ever sees ciphertext, so the choice of adapter cannot weaken confidentiality at rest. I verified this rather than assuming it: a test asserts the JWE written to storage contains none of the plaintext credential fields.

## Testing

Verified in Node against `pouchdb-adapter-memory`, covering the uniqueness constraints in the `insertOne`/`updateOne` plugins and the `purge()` fallback.

**The repository's karma browser suite was not run**, so the IndexedDB path is unverified by me beyond being unchanged by this diff.

Separately, the change has been exercised end to end on iOS against `pouchdb-adapter-react-native-sqlite`: an encrypted EDV created, written, closed, and reopened across a cold restart, decrypting correctly.

## Open questions

1. **Is `setAdapter()` the preferred seam?** The alternative is a `react-native` conditional export plus a dedicated `adapter-react-native.js`, which keeps configuration out of the runtime API entirely. I went with the runtime seam because it is a smaller change, but the conditional-export approach matches the pattern used elsewhere in the DB tree and I would defer to a maintainer preference here.

2. **What should `purge()`'s contract be for non-IndexedDB adapters?** Currently "compact instead, report 0 deleted". The alternative is throwing `NotSupportedError` so callers decide. Worth noting the existing IndexedDB path already returns bare `undefined` in one branch, so the return shape was never uniform.

3. **Do the documented non-atomic uniqueness semantics hold on SQLite?** The `insertOne`/`updateOne` plugins document specific non-atomic behavior for the uniqueness checks. SQLite's transactional behavior may change those failure modes rather than preserving them. I wrote a concurrency test that passes against the RN SQLite adapter, but it cannot prove the absence of a race — **this is the main correctness risk in the change and the question I would most like a maintainer's read on.**

---

Context: this came out of a prototype React Native wallet, which needed this package to run on a host with no IndexedDB. Filed as a draft because the seam is a design decision that belongs to the maintainers, not because the code is unfinished.
