### PR TITLE
Declare tweetnacl as a dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-web-pouch-edv ChangeLog
 
+## 8.2.1 - 2026-07-dd
+
+### Fixed
+- Declare `tweetnacl` as a dependency. `lib/X25519Kak.js` imports it directly,
+  but it was never listed in `package.json` and was previously satisfied
+  transitively. It is no longer reachable that way, so a clean install fails to
+  resolve it and the karma suite reports `Cannot find module 'tweetnacl'` before
+  any test runs.
+
 ## 8.2.0 - 2025-07-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "base58-universal": "^2.0.0",
     "pouchdb": "^9.0.0",
     "pouchdb-adapter-indexeddb": "^9.0.0",
-    "pouchdb-find": "^9.0.0"
+    "pouchdb-find": "^9.0.0",
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "eslint": "^8.57.1",


### PR DESCRIPTION
`lib/X25519Kak.js:6` does `import nacl from 'tweetnacl'`, but `tweetnacl` has never been listed in `package.json`. A clean install cannot resolve it: webpack fails to bundle and the karma suite reports `Cannot find module 'tweetnacl'` with 0 tests run.

This affects `main`, not just one branch — verified by cloning `main` fresh and running `npm install`, which leaves `tweetnacl` absent.

## Why it used to resolve

`tweetnacl` was a real transitive dependency, and then stopped being one:

| `@digitalbazaar/minimal-cipher` | `tweetnacl` |
|---|---|
| `5.0.0`, `5.1.0` | **`dependencies`** — installed transitively |
| `5.2.0` onward | dropped from `dependencies` |
| `6.x` (current) | present only in **`devDependencies`** |

npm does not install transitive devDependencies, so once the 6.x line became the resolved version the module stopped arriving. The import in `X25519Kak.js` dates to 2023-11-07 and was fine for as long as a 5.0/5.1 `minimal-cipher` was in the tree; nothing in `lib/` changed to break it.

`main`'s last green CI run was 2025-07-18, and no CI has run on `main` since, so the regression went unnoticed until now.

The `devDependencies` entry in 6.x is also why a casual `npm view … dependencies` check comes up empty — the reference is real but in a field npm won't install transitively.

## Verification

Reproduced in both directions locally with the karma suite:

| `tweetnacl` | Result |
|---|---|
| absent from `node_modules` | `Cannot find module 'tweetnacl'`, **0 tests completed** — identical to CI |
| declared + installed | **129 tests pass** |

Also confirmed the two APIs `X25519Kak.js` uses — `nacl.box.keyPair()` and `nacl.scalarMult()` — work with the declared version.

CI on this branch: `test-karma (22.x)` and `lint (22.x)` both pass.

## Version choice

`^1.0.3` matches what `minimal-cipher@5.x` used to bring in and is the current latest, so this restores the prior resolved version rather than changing behavior.

## Scope

One line in `dependencies`, plus a CHANGELOG entry. No source changes.

Found while working on #17, which is blocked by this failure; that PR's diff touches neither `X25519Kak.js` nor `package.json`. Filed separately so the fix lands on `main` on its own.